### PR TITLE
Use first argument to get filename and add shebang

### DIFF
--- a/carvbin2lite.py
+++ b/carvbin2lite.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Script en Python 3.7 
 # Carving de bbdd SQLite3, busqueda y extraccion de los archivos.
 # No confundir con obtener datos borrados dentro de la bbdd

--- a/carvbin2lite.py
+++ b/carvbin2lite.py
@@ -4,6 +4,8 @@
 # No confundir con obtener datos borrados dentro de la bbdd
 # 
 
+import sys
+
 
 sqlhead = ("53", "514c69746520666f726d6174203300")
 # cabecera del archivo y longitud
@@ -101,12 +103,12 @@ def contr_integridad(inicio):
 
 
 
-if __name__ == "__main__":
+def main(argv):
         # abrimos archivo en modo lectura binario
         # calculamos longitud y establecemos variables de control
 
         # arch = open("corta.dd", "rb")
-        arch = open("eepc.001", "rb")
+        arch = open(argv[0], "rb")
         lenar = arch.seek(0,2) 
         #arch.seek(0)
         print("Longitud de archivo", lenar)# depuracion
@@ -134,3 +136,10 @@ if __name__ == "__main__":
 
 
         arch.close()
+
+if __name__ == "__main__":
+        _script_argv = sys.argv[1:]
+        if len(_script_argv) == 0:
+                print("Usage: %s filename" % (sys.argv[0]))
+        else:
+                main(_script_argv)


### PR DESCRIPTION
Now it's possible to use it:
```bash
./carvbin2lite.py filename.bin
```

Also it's possible enhacement what to do with arguments, as potions, etc; or read more of one file to process, but at least now not to need edit filename in script.